### PR TITLE
Rearranging a few AV-BUS pins

### DIFF
--- a/connectors/module-hefty/micro-ribbon-36/micro-ribbon-36.yaml
+++ b/connectors/module-hefty/micro-ribbon-36/micro-ribbon-36.yaml
@@ -8,6 +8,8 @@ description: >
   wall of insulating material.
   Larger versions of these connectors, such as `micro-ribbon-50` are frequently
   used by telephone companies.
+reference:
+  - https://www.lammertbies.nl/comm/cable/parallel.html
 capabilities:
   - DC Power
   - Analog HD Video
@@ -36,26 +38,26 @@ contacts:
   12: spi-master-in-slave-out
   13: spi-clock
   14: host-reset
-  16: common
-  17: common
+  16: - av-bus-audio-special-effects
+      - common
+  17: - common
+      - shield
   18: no-connection
-  19: common
-  20: common
+  19 & 20:
+      - av-bus-video-separate-luminance
+      - av-bus-video-component-pr
+      - common
   21: common
   22: common
-  23: common
-  24: common
+  23 & 24:
+      - av-bus-common
+      - common
   25: common
   26: common
-  27: common
-  28: common
-  29: common
-  30: common
-  31: - av-bus-video-separate-luminance
-      - av-bus-video-component-pr
-  32: regulated-five-volts
-  33: common
-  34: no-connection
-  35: no-connection
-  36: - av-bus-video-separate-chrominance
-      - av-bus-video-component-y
+  27: - av-bus-audio-left
+      - common
+  28 & 29:
+      - av-bus-audio-right
+      - common
+  30: - av-bus-audio-special-effects
+      - common

--- a/connectors/module-internal/header-10/header-10.yaml
+++ b/connectors/module-internal/header-10/header-10.yaml
@@ -1,0 +1,20 @@
+name: Header 10 Pin
+description: >
+  The companion header for the Retro Specification DE-9 connector.
+tips:
+  - Consider using this connector on an Arduino shield to conform the Arduino
+    to the Retro Specification. Source a 10-pin header to DE-9 connector cable
+    from an old PC.
+aliases:
+  - D-sub 9
+  - DB-9
+contacts:
+  1: twenty-volts-max
+  2: controller-area-network-low
+  3: controller-area-network-high
+  4: common
+  5: pixel-data
+  6: digital-reference
+  7: i2c-clock
+  8: i2c-data
+  9: common

--- a/connectors/module-internal/header-26/header-26.yaml
+++ b/connectors/module-internal/header-26/header-26.yaml
@@ -40,14 +40,21 @@ contacts:
   16: av-bus-audio-mic
   17: - av-bus-video-composite
       - av-bus-video-component-pb
+      - common
   18: - av-bus-video-separate-luminance
       - av-bus-video-component-pr
+      - common
   19: - av-bus-video-separate-chrominance
       - av-bus-video-component-y
+      - common
   20: common
-  21: av-bus-common
+  21: - av-bus-common
+      - common
   22: common
-  23: av-bus-audio-left
-  24: av-bus-audio-right
-  25: av-bus-audio-special-effects
+  23: - av-bus-audio-left
+      - common
+  24: - av-bus-audio-right
+      - common
+  25: - av-bus-audio-special-effects
+      - common
   26: reserved

--- a/connectors/module-internal/header-26/header-26.yaml
+++ b/connectors/module-internal/header-26/header-26.yaml
@@ -37,13 +37,13 @@ contacts:
   13: spi-clock
   14: host-reset
   15: regulated-five-volts
-  16: - av-bus-video-separate-luminance
-      - av-bus-video-component-pr
-  17: - av-bus-video-separate-chrominance
-      - av-bus-video-component-y
-  18: - av-bus-video-composite
+  16: av-bus-audio-mic
+  17: - av-bus-video-composite
       - av-bus-video-component-pb
-  19: av-bus-audio-mic
+  18: - av-bus-video-separate-luminance
+      - av-bus-video-component-pr
+  19: - av-bus-video-separate-chrominance
+      - av-bus-video-component-y
   20: common
   21: av-bus-common
   22: common

--- a/connectors/module/card-edge-26/card-edge-26.yaml
+++ b/connectors/module/card-edge-26/card-edge-26.yaml
@@ -40,14 +40,21 @@ contacts:
   16: av-bus-audio-mic
   17: - av-bus-video-composite
       - av-bus-video-component-pb
+      - common
   18: - av-bus-video-separate-luminance
       - av-bus-video-component-pr
+      - common
   19: - av-bus-video-separate-chrominance
       - av-bus-video-component-y
+      - common
   20: common
-  21: av-bus-common
+  21: - av-bus-common
+      - common
   22: common
-  23: av-bus-audio-left
-  24: av-bus-audio-right
-  25: av-bus-audio-special-effects
+  23: - av-bus-audio-left
+      - common
+  24: - av-bus-audio-right
+      - common
+  25: - av-bus-audio-special-effects
+      - common
   26: reserved

--- a/connectors/module/card-edge-26/card-edge-26.yaml
+++ b/connectors/module/card-edge-26/card-edge-26.yaml
@@ -37,13 +37,13 @@ contacts:
   13: spi-clock
   14: host-reset
   15: regulated-five-volts
-  16: - av-bus-video-separate-luminance
-      - av-bus-video-component-pr
-  17: - av-bus-video-separate-chrominance
-      - av-bus-video-component-y
-  18: - av-bus-video-composite
+  16: av-bus-audio-mic
+  17: - av-bus-video-composite
       - av-bus-video-component-pb
-  19: av-bus-audio-mic
+  18: - av-bus-video-separate-luminance
+      - av-bus-video-component-pr
+  19: - av-bus-video-separate-chrominance
+      - av-bus-video-component-y
   20: common
   21: av-bus-common
   22: common

--- a/connectors/module/dsub-db-25/dsub-db-25.yaml
+++ b/connectors/module/dsub-db-25/dsub-db-25.yaml
@@ -46,13 +46,13 @@ contacts:
   13: spi-clock
   14: host-reset
   15: regulated-five-volts
-  16: - av-bus-video-separate-luminance
-      - av-bus-video-component-pr
-  17: - av-bus-video-separate-chrominance
-      - av-bus-video-component-y
-  18: - av-bus-video-composite
+  16: av-bus-audio-mic
+  17: - av-bus-video-composite
       - av-bus-video-component-pb
-  19: av-bus-audio-mic
+  18: - av-bus-video-separate-luminance
+      - av-bus-video-component-pr
+  19: - av-bus-video-separate-chrominance
+      - av-bus-video-component-y
   20: common
   21: av-bus-common
   22: common

--- a/connectors/module/dsub-db-25/dsub-db-25.yaml
+++ b/connectors/module/dsub-db-25/dsub-db-25.yaml
@@ -49,13 +49,20 @@ contacts:
   16: av-bus-audio-mic
   17: - av-bus-video-composite
       - av-bus-video-component-pb
+      - common
   18: - av-bus-video-separate-luminance
       - av-bus-video-component-pr
+      - common
   19: - av-bus-video-separate-chrominance
       - av-bus-video-component-y
+      - common
   20: common
-  21: av-bus-common
+  21: - av-bus-common
+      - common
   22: common
-  23: av-bus-audio-left
-  24: av-bus-audio-right
-  25: av-bus-audio-special-effects
+  23: - av-bus-audio-left
+      - common
+  24: - av-bus-audio-right
+      - common
+  25: - av-bus-audio-special-effects
+      - common

--- a/modules/client/adapters/adapter-power-brick/adapter-power-brick.yaml
+++ b/modules/client/adapters/adapter-power-brick/adapter-power-brick.yaml
@@ -1,0 +1,21 @@
+name: Adapter - Power Brick
+summary: Use the power from an old laptop or printer brick.
+description: >
+  Most laptop power supplies output right around 19VDC. If you have a power
+  brick stating it supplies twenty volts or less, it can be easily integrated
+  into your collection of modules. Most connectors in The Retro Specification
+  have one or more `twenty-volts-max` contacts. Power can be passed through
+  one module to another with ease. If a module requires power, it can use
+  either power from the `regulated-five-volts` bus or power from the
+  `twenty-volts-max` bus. If a particular module is power-hungry, it should
+  prefer power from the `twenty-volts-max` bus... and could fall back to the
+  `regulated-five-volts` bus if necessary (e.g. low-power mode).
+  Many inexpensive voltage regulators can tolerate up to about twenty volts.
+  The power needs of one module may differ from that of another. A five volt
+  regulator may be your regulator of choice, but certain modules may need
+  twelve volts or more. The `twenty-volts-max` bus provides some flexibility.
+connectors:
+  - dsub-db-25
+  - dsub-da-15
+  - dsub-de-9
+  - din8

--- a/modules/client/adapters/adapter-usb-battery-pack/adapter-usb-battery-pack.yaml
+++ b/modules/client/adapters/adapter-usb-battery-pack/adapter-usb-battery-pack.yaml
@@ -1,0 +1,18 @@
+name: Adapter - USB Battery Pack
+summary: Use any off-the-shelf battery USB device charger.
+description: >
+  Traditional USB ports provide five volts regulated power. Pocket USB battery
+  packs usually feature a LiPo battery, a 5V voltage regulator & charge
+  controller. They typically are charged via a micro-USB port.
+  Most of the connectors in The Retro Specification include a
+  `regulated-five-volts` contact. Since Retro Modules are daisy-chainable,
+  that regulated power is passed from one module to another. If a particular
+  module requires power, it can tap into that 5V bus.
+  Most connectors also include one or more `twenty-volts-max` contacts. These
+  contacts could easily be connected to a 6V, 9V, 12V or 19V power source. With
+  a 20V-tolerant 5V voltage regulator, the USB battery pack could be charged
+  from a variety of sources.
+connectors:
+  - dsub-db-25
+  - usb-a
+  - usb-micro

--- a/modules/client/input/receiver-radio-control-receiver/receiver-radio-control-receiver.yaml
+++ b/modules/client/input/receiver-radio-control-receiver/receiver-radio-control-receiver.yaml
@@ -1,6 +1,9 @@
 ---
 name: RC Radio Receiver Module
 summary: A module tuned to receive commands from off-the-shelf RC controllers.
+reference:
+  - http://www.nordicsemi.com/eng/Products/2.4GHz-RF/nRF24L01P
+  - http://www.instructables.com/id/Wireless-Remote-Using-24-Ghz-NRF24L01-Simple-Tutor/?ALLSTEPS
 categories:
   - input
   - costume

--- a/modules/client/input/sensor-face-position-tracker/sensor-face-position-tracker.yaml
+++ b/modules/client/input/sensor-face-position-tracker/sensor-face-position-tracker.yaml
@@ -6,9 +6,10 @@ notes:
 tips:
   - Program robot eyes to look at primary subject
   - Program robot head to shift toward primary subject
+reference:
+  - http://charmedlabs.com/default/pixy-cmucam5
+  - sensor-face-feature-tracker
 categories:
   - input
   - costume
   - prop
-reference:
-  - sensor-face-feature-tracker


### PR DESCRIPTION
This counts as a more significant revision. The DB-25 connector presents a slight problem in that many DB-25 printer cables tie pins 18-25 to common/ground. Most of the pins in _this_ specification between 18-25 are consumer-equipment-friendly analog signals. Many consumer analog AV devices can tolerate the shorting of analog inputs or outputs to ground (at least for short periods). I realized recently that there is a higher risk of equipment damage if an electret microphone is connected to the `av-bus-audio-mic` contact. The `av-bus-audio-mic` bus is presently on contact 19. It has been moved to contact 16. As a matter of convenience, `av-bus-video-composite` has been moved to contact 17. With these revisions, one would have _safe_ access to the `av-bus-audio-mic` & `av-bus-video-composite` pins if using an old printer cable. Using an old printer cable is not the best way to send analog signals (especially if noisy digital signals are running alongside) but would work if in a pinch. The best approach is to make a custom cable that shields the analog signals from the digital & power signals if you plan to use the spec for analog AV + digital.
This PR also includes some minor additions which are unrelated to the above topic.
