### PR TITLE
Retro Modules v1.2 Proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## V1.2
+This version optimizes the most commonly used connectors in the specification
+to reduce the need for numerous voltage regulators & further refines clean
+signal support.
+
+* Adds dedicated common bus for digital signals on many connectors.
+* Revises main connectors to support 6 & 40 volts max contacts.
+* Adds support for balanced audio on main 25 contact connectors.
+
 ## V1.1
 * Each module connector must only have digital signals with 3.3V logic level.
     If the components within the module has a differing logic level, it must be

--- a/connectors/audio-phone-mini-trrs/audio-phone-mini-trrs.yaml
+++ b/connectors/audio-phone-mini-trrs/audio-phone-mini-trrs.yaml
@@ -6,8 +6,8 @@ description: >
   It is less-commonly used to route a pair of analog audio signals and a
   composite video signal from an AV device.
   Many older mobile devices featured `common` on the `sleeve` and
-  `av-bus-audio-electret-mic` on `ring_1`. This spec was rejected in favor of
-  `common` on `ring_1`. This allowed new headsets to be better compatible
+  `av-bus-audio-electret-mic` on `ring_2`. This spec was rejected in favor of
+  `common` on `ring_2`. This allowed new headsets to be better compatible
   with both `trs` & `trrs` receptacles.
 reference:
   - https://en.wikipedia.org/wiki/Phone_connector_%28audio%29
@@ -20,12 +20,17 @@ note: The most common spec for each contact is listed first.
 contacts:
   tip:
     - av-bus-audio-left
+    - av-bus-video-component-y
+    - av-bus-video-chrominance
   ring:
     - av-bus-audio-right
+    - av-bus-video-component-pb
     - av-bus-video-composite
-  ring_1:
+  ring_2:
     - av-bus-common
     - av-bus-audio-electret-mic
+    - av-bus-video-component-pr
+    - av-bus-video-luminance
   sleeve:
     - av-bus-audio-electret-mic
     - av-bus-video-composite

--- a/connectors/audio-pro-xlr5-mini/audio-pro-xlr5-mini.yaml
+++ b/connectors/audio-pro-xlr5-mini/audio-pro-xlr5-mini.yaml
@@ -32,7 +32,7 @@ reference:
   - http://www.androidcentral.com/quick-charge
 contacts:
   1: digital-audio-spdif
-  2: controller-area-network-low
-  3: controller-area-network-high
+  2: io-controller-area-network-low
+  3: io-controller-area-network-high
   4: common
   5: forty-volts-max

--- a/connectors/aviation-gx12-4/aviation-gx12-4.yaml
+++ b/connectors/aviation-gx12-4/aviation-gx12-4.yaml
@@ -14,5 +14,5 @@ keywords:
 contacts:
   1: common
   2: sixty-volts-max
-  3: controller-area-network-low
-  4: controller-area-network-high
+  3: io-controller-area-network-low
+  4: io-controller-area-network-high

--- a/connectors/aviation-gx12-5/aviation-gx12-5.yaml
+++ b/connectors/aviation-gx12-5/aviation-gx12-5.yaml
@@ -14,6 +14,6 @@ keywords:
 contacts:
   1: common
   2: sixty-volts-max
-  3: controller-area-network-low
-  4: controller-area-network-high
+  3: io-controller-area-network-low
+  4: io-controller-area-network-high
   5: reserved

--- a/connectors/aviation-gx12-6/aviation-gx12-6.yaml
+++ b/connectors/aviation-gx12-6/aviation-gx12-6.yaml
@@ -15,7 +15,7 @@ keywords:
 contacts:
   1: common
   2: sixty-volts-max
-  3: controller-area-network-low
-  4: controller-area-network-high
+  3: io-controller-area-network-low
+  4: io-controller-area-network-high
   5: digital-audio-aes-host-out-client-in-negative
   6: digital-audio-aes-host-out-client-in-positive

--- a/connectors/aviation-gx16-4/aviation-gx16-4.yaml
+++ b/connectors/aviation-gx16-4/aviation-gx16-4.yaml
@@ -15,5 +15,5 @@ keywords:
 contacts:
   1: common
   2: twelve-volts-nominal-switched
-  3: pixel-data
-  4: one-wire-data
+  3: io-pixel-data
+  4: io-one-wire-data

--- a/connectors/aviation-gx16-5/aviation-gx16-5.yaml
+++ b/connectors/aviation-gx16-5/aviation-gx16-5.yaml
@@ -15,6 +15,6 @@ keywords:
 contacts:
   1: common
   2: twelve-volts-nominal-switched
-  3: pixel-data
-  4: one-wire-data
+  3: io-pixel-data
+  4: io-one-wire-data
   5: twelve-volts-nominal

--- a/connectors/aviation-gx16-6/aviation-gx16-6.yaml
+++ b/connectors/aviation-gx16-6/aviation-gx16-6.yaml
@@ -17,7 +17,7 @@ buy:
 contacts:
   1: common
   2: twelve-volts-nominal-switched
-  3: pixel-data
-  4: one-wire-data
+  3: io-pixel-data
+  4: io-one-wire-data
   5: twelve-volts-nominal
   6: common

--- a/connectors/aviation-gx16-7/aviation-gx16-7.yaml
+++ b/connectors/aviation-gx16-7/aviation-gx16-7.yaml
@@ -19,6 +19,6 @@ contacts:
   2: common
   3: twelve-volts-nominal
   4: twelve-volts-nominal-switched
-  5: controller-area-network-low
-  6: controller-area-network-high
+  5: io-controller-area-network-low
+  6: io-controller-area-network-high
   7: digital-audio-spdif

--- a/connectors/can-cia-102/can-cia-102.yaml
+++ b/connectors/can-cia-102/can-cia-102.yaml
@@ -18,7 +18,7 @@ contacts:
     - regulated-twelve-volts
     - regulated-five-volts
     - no-connection
-  2: controller-area-network-low
+  2: io-controller-area-network-low
   3:
     - common
     - no-connection
@@ -27,7 +27,7 @@ contacts:
   6:
     - common
     - no-connection
-  7: controller-area-network-high
+  7: io-controller-area-network-high
   8: no-connection
   9:
     - regulated-twelve-volts

--- a/connectors/card-edge-10/card-edge-10.yaml
+++ b/connectors/card-edge-10/card-edge-10.yaml
@@ -14,12 +14,12 @@ keywords:
   - d-sub 9
   - de-9
 contacts:
-  1: one-wire-data
-  2: controller-area-network-low
-  3: controller-area-network-high
-  4: common-reset
-  5: fifteen-volts-max
-  6: common-power-request
-  7: i2c-clock
-  8: i2c-data
+  1: io-one-wire-data
+  2: io-controller-area-network-low
+  3: io-controller-area-network-high
+  4: io-common
+  5: forty-volts-max
+  6: six-volts-max
+  7: io-i2c-clock
+  8: io-i2c-data
   9: common

--- a/connectors/card-edge-26/card-edge-26.yaml
+++ b/connectors/card-edge-26/card-edge-26.yaml
@@ -15,14 +15,14 @@ keywords:
   - d-sub 25
   - db-25
 contacts:
-  1: spi-clock
-  2: controller-area-network-high
-  3: controller-area-network-low
-  4: i2c-clock
-  5: i2c-data
-  6: common-power-request
-  7: fifteen-volts-max
-  8: one-wire-data
+  1: io-spi-clock
+  2: io-controller-area-network-high
+  3: io-controller-area-network-low
+  4: io-i2c-clock
+  5: io-i2c-data
+  6: six-volts-max
+  7: forty-volts-max
+  8: io-one-wire-data
   9: forty-volts-max
   10: forty-volts-max
   11: av-bus-common
@@ -34,9 +34,9 @@ contacts:
     - av-bus-audio-line-level-right
     - av-bus-audio-line-level-aux-send-2
     - av-bus-audio-line-level-channel-2
-  14: spi-controller-out-peripheral-in
-  15: spi-controller-in-peripheral-out
-  16: spi-chip-select
+  14: io-spi-controller-out-peripheral-in
+  15: io-spi-controller-in-peripheral-out
+  16: io-spi-chip-select
   17:
     - av-bus-video-composite
     - av-bus-video-component-pb
@@ -49,7 +49,7 @@ contacts:
     - av-bus-video-separate-chrominance
     - av-bus-video-component-y
     - common
-  20: common-reset
+  20: io-common
   21: common
   22: common
   23: common
@@ -57,9 +57,11 @@ contacts:
     - av-bus-audio-line-level-aux-left
     - av-bus-audio-line-level-aux-return-1
     - av-bus-audio-line-level-channel-3
+    - av-bus-audio-line-level-channel-1-phase-inverted
     - common
   25:
     - av-bus-audio-line-level-aux-right
     - av-bus-audio-line-level-aux-return-2
     - av-bus-audio-line-level-channel-4
+    - av-bus-audio-line-level-channel-2-phase-inverted
     - common

--- a/connectors/din5-240/din5-240.yaml
+++ b/connectors/din5-240/din5-240.yaml
@@ -6,7 +6,7 @@ description:
   the vast array of 12VDC vehicle & RC accessories without introducing
   any extra complexity.
   If a device requires more than 12 volts, it can request it via the
-  `one-wire-data` contact. It is merely a request, though. If there is a
+  `io-one-wire-data` contact. It is merely a request, though. If there is a
   module regulating power on pins 4 & 5, it may adjust its output voltage
   if equipped to do so.
   To remain safe, modules should not provide more than 50VDC.
@@ -27,7 +27,7 @@ aliases:
 compatible:
   - din6-240
 contacts:
-  1: one-wire-data
+  1: io-one-wire-data
   2: common
   3: common
   4:

--- a/connectors/din5-270/din5-270.yaml
+++ b/connectors/din5-270/din5-270.yaml
@@ -12,6 +12,6 @@ compatible:
 contacts:
   4: regulated-five-volts
   5: common
-  6: controller-area-network-low
-  7: controller-area-network-high
+  6: io-controller-area-network-low
+  7: io-controller-area-network-high
   8: forty-volts-max

--- a/connectors/din6-240/din6-240.yaml
+++ b/connectors/din6-240/din6-240.yaml
@@ -6,7 +6,7 @@ description:
   the vast array of 12VDC vehicle & RC accessories without introducing
   any extra complexity.
   If a device requires more than 12 volts, it can request it via the
-  `one-wire-data` contact. It is merely a request, though. If there is a
+  `io-one-wire-data` contact. It is merely a request, though. If there is a
   module regulating power on pins 4 & 5, it may adjust its output voltage
   if equipped to do so.
   To remain safe, modules should not provide more than 50VDC.
@@ -29,7 +29,7 @@ keywords:
 aliases:
   - din-45522
 contacts:
-  1: one-wire-data
+  1: io-one-wire-data
   2: common
   3: common
   4:
@@ -39,5 +39,5 @@ contacts:
     - twelve-volts-nominal
     - negotiated-voltage
   6:
-    - pixel-data
-    - pwm
+    - io-pixel-data
+    - io-pwm

--- a/connectors/din7/din7.yaml
+++ b/connectors/din7/din7.yaml
@@ -14,5 +14,5 @@ contacts:
   3: av-bus-audio-right
   4: regulated-five-volts
   5: common
-  6: controller-area-network-low
-  7: controller-area-network-high
+  6: io-controller-area-network-low
+  7: io-controller-area-network-high

--- a/connectors/din8/din8.yaml
+++ b/connectors/din8/din8.yaml
@@ -12,8 +12,8 @@ contacts:
   3: av-bus-audio-right
   4: regulated-five-volts
   5: common
-  6: controller-area-network-low
-  7: controller-area-network-high
+  6: io-controller-area-network-low
+  7: io-controller-area-network-high
   8:
-    - fifteen-volts-max
+    - forty-volts-max
     - negotiated-voltage

--- a/connectors/dsub-da-15/dsub-da-15.yaml
+++ b/connectors/dsub-da-15/dsub-da-15.yaml
@@ -4,8 +4,8 @@ aliases:
   - DB-15
   - D-sub 15
 contacts:
-  1: one-wire-data
-  2: id
+  1: io-one-wire-data
+  2: io-id
   3: series-sum
   4: common
   5: series-balance-ref-0

--- a/connectors/dsub-db-17w2/dsub-db-17w2.yaml
+++ b/connectors/dsub-db-17w2/dsub-db-17w2.yaml
@@ -31,10 +31,10 @@ contacts:
   8: av-bus-audio-channel-4-balanced-negative
   9: av-bus-common
   10: common
-  11: one-wire-data
-  12: spdif
-  13: digital-audio-aes-negative
-  14: digital-audio-aes-positive
+  11: io-one-wire-data
+  12: io-spdif
+  13: io-digital-audio-aes-negative
+  14: io-digital-audio-aes-positive
   15: twelve-volts-nominal-amplifier-request
   a1: common
   a2: twelve-volts-nominal

--- a/connectors/dsub-db-25/dsub-db-25.yaml
+++ b/connectors/dsub-db-25/dsub-db-25.yaml
@@ -31,7 +31,7 @@ notes:
           contact.
       - The power supply positive is connected to the SPST 'Normally-Open'
         contact.
-      - The SPST relay is energized if `common-power-request` is connected to
+      - The SPST relay is energized if `io-common-power-request` is connected to
         `common`. This connects the power supply positive to the
         `forty-volts-max` contact.
     complex:
@@ -39,18 +39,18 @@ notes:
         supply and the `forty-volts-max` contact.
       - This microcontroller may be part of a typical ATX PC power supply.
       - Microcontrollers within different power supplies may coordinate.
-        If `common-power-request` is connected to `common`, the power supply
+        If `io-common-power-request` is connected to `common`, the power supply
         microcontrollers can automatically nominate one supply as the official
         power source, while all others go into standby mode.
 contacts:
-  1: spi-clock
-  2: controller-area-network-high
-  3: controller-area-network-low
-  4: i2c-clock
-  5: i2c-data
-  6: common-power-request
-  7: fifteen-volts-max
-  8: one-wire-data
+  1: io-spi-clock
+  2: io-controller-area-network-high
+  3: io-controller-area-network-low
+  4: io-i2c-clock
+  5: io-i2c-data
+  6: six-volts-max
+  7: forty-volts-max
+  8: io-one-wire-data
   9: forty-volts-max
   10: forty-volts-max
   11: av-bus-common
@@ -62,9 +62,9 @@ contacts:
     - av-bus-audio-line-level-right
     - av-bus-audio-line-level-aux-send-2
     - av-bus-audio-line-level-channel-2
-  14: spi-controller-out-peripheral-in
-  15: spi-controller-in-peripheral-out
-  16: spi-chip-select
+  14: io-spi-controller-out-peripheral-in
+  15: io-spi-controller-in-peripheral-out
+  16: io-spi-chip-select
   17:
     - av-bus-video-composite
     - av-bus-video-component-pb
@@ -77,7 +77,7 @@ contacts:
     - av-bus-video-separate-chrominance
     - av-bus-video-component-y
     - common
-  20: common-reset
+  20: io-common
   21: common
   22: common
   23: common
@@ -85,9 +85,11 @@ contacts:
     - av-bus-audio-line-level-aux-left
     - av-bus-audio-line-level-aux-return-1
     - av-bus-audio-line-level-channel-3
+    - av-bus-audio-line-level-channel-1-phase-inverted
     - common
   25:
     - av-bus-audio-line-level-aux-right
     - av-bus-audio-line-level-aux-return-2
     - av-bus-audio-line-level-channel-4
+    - av-bus-audio-line-level-channel-2-phase-inverted
     - common

--- a/connectors/dsub-dc-13w6/dsub-dc-13w6.yaml
+++ b/connectors/dsub-dc-13w6/dsub-dc-13w6.yaml
@@ -3,13 +3,13 @@ summary: 70V Max 120A Max High-Current Connector
 notes:
   - Connector may accomodate either 20A or 40A on all `a` contacts.
 contacts:
-  1: one-wire-data
+  1: io-one-wire-data
   2: reserved
   3: reserved
   4: reserved
   5: common-power-request
-  6: controller-area-network-low
-  7: controller-area-network-high
+  6: io-controller-area-network-low
+  7: io-controller-area-network-high
   a1: seventy-volts-max
   a2: seventy-volts-max
   a3: seventy-volts-max

--- a/connectors/dsub-dc-21w4/dsub-dc-21w4.yaml
+++ b/connectors/dsub-dc-21w4/dsub-dc-21w4.yaml
@@ -8,10 +8,10 @@ notes:
   - Consider used `18650` batteries for your battery pack.
   - Consider the `25R` series of `18650` batteries for better performance.
   - Battery packs may include temperature sensor(s) & that data could be
-    requested via `one-wire-data` or CAN.
+    requested via `io-one-wire-data` or CAN.
   - Battery packs may include a voltage monitoring chip & data could be
-    requested via `one-wire-data` or CAN.
-  - Information about the battery pack could be requested via `one-wire-data`
+    requested via `io-one-wire-data` or CAN.
+  - Information about the battery pack could be requested via `io-one-wire-data`
     for automatic charge controller configuration.
 contacts:
   1: reserved

--- a/connectors/dsub-dc-27w2/dsub-dc-27w2.yaml
+++ b/connectors/dsub-dc-27w2/dsub-dc-27w2.yaml
@@ -8,15 +8,15 @@ notes:
   - Consider used `18650` batteries for your battery pack.
   - Consider the `25R` series of `18650` batteries for better performance.
   - Battery packs may include temperature sensor(s) & that data could be
-    requested via `one-wire-data` or CAN.
+    requested via `io-one-wire-data` or CAN.
   - Battery packs may include a voltage monitoring chip & data could be
-    requested via `one-wire-data` or CAN.
-  - Information about the battery pack could be requested via `one-wire-data`
+    requested via `io-one-wire-data` or CAN.
+  - Information about the battery pack could be requested via `io-one-wire-data`
     for automatic charge controller configuration.
 contacts:
-  1: 1-wire
-  2: controller-area-network-low
-  3: controller-area-network-high
+  1: io-one-wire-data
+  2: io-controller-area-network-low
+  3: io-controller-area-network-high
   4: reserved
   5: reserved
   6: reserved

--- a/connectors/dsub-dc-37/dsub-dc-37.yaml
+++ b/connectors/dsub-dc-37/dsub-dc-37.yaml
@@ -19,8 +19,8 @@ aliases:
 references:
   - http://www.pidramble.com
 contacts:
-  1: one-wire-data
-  2: controller-area-network-low
+  1: io-one-wire-data
+  2: io-controller-area-network-low
   3: usb-data-low
   4: usb-data-ss-rx-low
   5: usb-data-ss-tx-low
@@ -38,7 +38,7 @@ contacts:
   17: base-t-data-b-low
   18: base-t-data-a-low
   19: base-t-data-d-low
-  20: controller-area-network-high
+  20: io-controller-area-network-high
   21: usb-data-high
   22: usb-data-ss-rx-high
   23: usb-data-ss-tx-high

--- a/connectors/dsub-dd-36w4/dsub-dd-36w4.yaml
+++ b/connectors/dsub-dd-36w4/dsub-dd-36w4.yaml
@@ -5,16 +5,16 @@ aliases:
 warnings:
   - This connector may feature dangerous voltages.
   - High-voltage contacts should be disconnected until power is
-    explicitly requested via the `common-power-request` contact.
+    explicitly requested via the `io-common-power-request` contact.
 notes:
   - Connector may accomodate either 20A or 40A on A1, A2, A3 & A4.
   - Consider used 18650 batteries for your battery pack.
   - Consider the 25R series of 18650 batteries for better performance.
   - Battery packs may include temperature sensor(s) & that data could be
-    requested via `one-wire-data` or CAN.
+    requested via `io-one-wire-data` or CAN.
   - Battery packs may include a voltage monitoring chip & data could be
-    requested via `one-wire-data` or CAN.
-  - Information about the battery pack could be requested via `one-wire-data`
+    requested via `io-one-wire-data` or CAN.
+  - Information about the battery pack could be requested via `io-one-wire-data`
     for automatic charge controller configuration.
 contacts:
   1: balance-cell-1
@@ -46,9 +46,9 @@ contacts:
   27: balance-cell-27
   28: balance-cell-28
   29: balance-cell-29
-  30: controller-area-network-low
-  31: controller-area-network-high
-  32: common-power-request
+  30: io-controller-area-network-low
+  31: io-controller-area-network-high
+  32: io-common-power-request
   a1: common
   a2: series-sum
   a3: series-sum

--- a/connectors/dsub-dd-50/dsub-dd-50.yaml
+++ b/connectors/dsub-dd-50/dsub-dd-50.yaml
@@ -39,10 +39,12 @@ contacts:
   12: v-ignition-engine
   13: v-dash-backlight
   14: v-dome-light
-  15: - v-trunk-light
-      - v-truck-bed-light
-  16: - v-flood-lights
-  17: - v-accent-lights
+  15:
+    - v-trunk-light
+    - v-truck-bed-light
+  16:
+    - v-flood-lights
+  17: v-accent-lights
 
   18: reserved
   19: reserved
@@ -75,6 +77,6 @@ contacts:
   45: common-switched-5
   46: common-switched-6
   47: common-switched-7
-  48: one-wire-data
-  49: controller-area-network-low
-  50: controller-area-network-high
+  48: io-one-wire-data
+  49: io-controller-area-network-low
+  50: io-controller-area-network-high

--- a/connectors/dsub-de-9/dsub-de-9.yaml
+++ b/connectors/dsub-de-9/dsub-de-9.yaml
@@ -10,12 +10,12 @@ aliases:
   - D-sub 9
   - DB-9
 contacts:
-  1: one-wire-data
-  2: controller-area-network-low
-  3: controller-area-network-high
-  4: common-reset
-  5: fifteen-volts-max
-  6: common-power-request
-  7: i2c-clock
-  8: i2c-data
+  1: io-one-wire-data
+  2: io-controller-area-network-low
+  3: io-controller-area-network-high
+  4: io-common
+  5: forty-volts-max
+  6: six-volts-max
+  7: io-i2c-clock
+  8: io-i2c-data
   9: common

--- a/connectors/gopro-backpack/gopro-backpack.yaml
+++ b/connectors/gopro-backpack/gopro-backpack.yaml
@@ -15,12 +15,14 @@ notes:
   - component video out activate by connecting ID2 to common
 contacts:
   1: common
-  2: - av-bus-composite
-     - av-bus-video-component-pb
-     - av-bus-video-component-cb
+  2:
+    - av-bus-composite
+    - av-bus-video-component-pb
+    - av-bus-video-component-cb
   3: av-bus-video-component-y
-  4: - av-bus-video-component-pr
-     - av-bus-video-component-cr
+  4:
+    - av-bus-video-component-pr
+    - av-bus-video-component-cr
   5: regulated-five-volts
   6: regulated-five-volts
   7: usb-data-positive
@@ -44,6 +46,6 @@ contacts:
   25: gopro-~ VBat+ external power input ?
   26: gopro-~ VBat+ external power input ?
   27: common
-  28: i2c-data
-  29: i2c-clock
+  28: io-i2c-data
+  29: io-i2c-clock
   30: common

--- a/connectors/header-1x4k2/header-1x4k2.yaml
+++ b/connectors/header-1x4k2/header-1x4k2.yaml
@@ -1,9 +1,12 @@
 name: Header 1x4k2
-summary: Simple Power Connector
-description: Four contact header with a polarizing key in position 2.
+summary: Type B Generic Power Connector
+description: Four contact header featuring power & 1-Wire data.
+aliases:
+  - gpb
+  - Type B Generic Power Connector
 contacts:
-  1: one-wire-data
+  1: io-one-wire-data
   3: common
-  4: fifteen-volts-max
+  4: six-volts-max
 keys:
   - 2

--- a/connectors/header-1x5k3/header-1x5k3.yaml
+++ b/connectors/header-1x5k3/header-1x5k3.yaml
@@ -1,0 +1,12 @@
+name: Header 1x5
+summary: Type A Generic Power Connector
+description: Palindromic five contact header featuring power & 1-Wire data.
+aliases:
+  - gpa
+  - Type A Generic Power Connector
+contacts:
+  1: forty-volts-max
+  2: common
+  3: io-one-wire-data
+  4: common
+  5: forty-volts-max

--- a/connectors/header-2x13/header-2x13.yaml
+++ b/connectors/header-2x13/header-2x13.yaml
@@ -18,14 +18,14 @@ keywords:
   - d-sub 25
   - db-25
 contacts:
-  1: spi-clock
-  2: controller-area-network-high
-  3: controller-area-network-low
-  4: i2c-clock
-  5: i2c-data
-  6: common-power-request
-  7: fifteen-volts-max
-  8: one-wire-data
+  1: io-spi-clock
+  2: io-controller-area-network-high
+  3: io-controller-area-network-low
+  4: io-i2c-clock
+  5: io-i2c-data
+  6: six-volts-max
+  7: forty-volts-max
+  8: io-one-wire-data
   9: forty-volts-max
   10: forty-volts-max
   11: av-bus-common
@@ -37,9 +37,9 @@ contacts:
     - av-bus-audio-line-level-right
     - av-bus-audio-line-level-aux-send-2
     - av-bus-audio-line-level-channel-2
-  14: spi-controller-out-peripheral-in
-  15: spi-controller-in-peripheral-out
-  16: spi-chip-select
+  14: io-spi-controller-out-peripheral-in
+  15: io-spi-controller-in-peripheral-out
+  16: io-spi-chip-select
   17:
     - av-bus-video-composite
     - av-bus-video-component-pb
@@ -52,7 +52,7 @@ contacts:
     - av-bus-video-separate-chrominance
     - av-bus-video-component-y
     - common
-  20: common-reset
+  20: io-common
   21: common
   22: common
   23: common
@@ -60,11 +60,13 @@ contacts:
     - av-bus-audio-line-level-aux-left
     - av-bus-audio-line-level-aux-return-1
     - av-bus-audio-line-level-channel-3
+    - av-bus-audio-line-level-channel-1-phase-inverted
     - common
   25:
     - av-bus-audio-line-level-aux-right
     - av-bus-audio-line-level-aux-return-2
     - av-bus-audio-line-level-channel-4
+    - av-bus-audio-line-level-channel-2-phase-inverted
     - common
 keys:
   - 26

--- a/connectors/header-2x5/header-2x5.yaml
+++ b/connectors/header-2x5/header-2x5.yaml
@@ -9,14 +9,14 @@ aliases:
   - D-sub 9
   - DB-9
 contacts:
-  1: one-wire-data
-  2: controller-area-network-low
-  3: controller-area-network-high
-  4: common-reset
-  5: fifteen-volts-max
-  6: common-power-request
-  7: i2c-clock
-  8: i2c-data
+  1: io-one-wire-data
+  2: io-controller-area-network-low
+  3: io-controller-area-network-high
+  4: io-common
+  5: forty-volts-max
+  6: six-volts-max
+  7: io-i2c-clock
+  8: io-i2c-data
   9: common
 keys:
   - 10

--- a/connectors/header-2x8/header-2x8.yaml
+++ b/connectors/header-2x8/header-2x8.yaml
@@ -5,8 +5,8 @@ references:
 buy:
   - http://www.networkcables.com/proddetail.php?prod=CO19MS
 contacts:
-  1: one-wire-data
-  2: id
+  1: io-one-wire-data
+  2: io-id
   3: series-sum
   4: common
   5: series-balance-ref-0

--- a/connectors/header-4x4/header-4x4.yaml
+++ b/connectors/header-4x4/header-4x4.yaml
@@ -17,18 +17,18 @@ reference:
   - https://hackaday.com/2019/03/20/introducing-the-shitty-add-on-v1-69bis-standard
 contacts:
   1: forty-volts-max
-  2: i2c-clock
-  3: i2c-data
+  2: io-i2c-clock
+  3: io-i2c-data
   4: forty-volts-max
-  5: i2c-data
+  5: io-i2c-data
   6: common
   7: common
-  8: i2c-clock
-  9: i2c-clock
+  8: io-i2c-clock
+  9: io-i2c-clock
   10: common
   11: common
-  12: i2c-data
+  12: io-i2c-data
   13: forty-volts-max
-  14: i2c-data
-  15: i2c-clock
+  14: io-i2c-data
+  15: io-i2c-clock
   16: forty-volts-max

--- a/connectors/micro-ribbon-36/micro-ribbon-36.yaml
+++ b/connectors/micro-ribbon-36/micro-ribbon-36.yaml
@@ -21,14 +21,14 @@ capabilities:
   - ICSP
 see: micro-ribbon
 contacts:
-  1: spi-clock
-  2: controller-area-network-high
-  3: controller-area-network-low
-  4: i2c-clock
-  5: i2c-data
-  6: common-power-request
-  7: fifteen-volts-max
-  8: one-wire-data
+  1: io-spi-clock
+  2: io-controller-area-network-high
+  3: io-controller-area-network-low
+  4: io-i2c-clock
+  5: io-i2c-data
+  6: six-volts-max
+  7: forty-volts-max
+  8: io-one-wire-data
   9: forty-volts-max
   10: forty-volts-max
   11: av-bus-common
@@ -40,7 +40,7 @@ contacts:
     - av-bus-audio-line-level-right
     - av-bus-audio-line-level-aux-send-2
     - av-bus-audio-line-level-channel-2
-  14: spi-controller-out-peripheral-in
+  14: io-spi-controller-out-peripheral-in
   15: reserved
   16:
     - av-bus-audio-line-level-aux-right
@@ -59,8 +59,8 @@ contacts:
     - av-bus-video-separate-chrominance
     - av-bus-video-component-y
     - common
-  21: common-reset
-  22: common-reset
+  21: io-common
+  22: io-common
   23: common
   24: common
   25: common
@@ -75,14 +75,16 @@ contacts:
     - av-bus-audio-line-level-aux-left
     - av-bus-audio-line-level-aux-return-1
     - av-bus-audio-line-level-channel-3
+    - av-bus-audio-line-level-channel-1-phase-inverted
     - common
   30:
     - av-bus-audio-line-level-aux-right
     - av-bus-audio-line-level-aux-return-2
     - av-bus-audio-line-level-channel-4
+    - av-bus-audio-line-level-channel-2-phase-inverted
     - common
-  31: spi-chip-select
-  32: spi-controller-in-peripheral-out
+  31: io-spi-chip-select
+  32: io-spi-controller-in-peripheral-out
   33:
     - av-bus-video-separate-luminance
     - av-bus-video-component-pr

--- a/connectors/rj11/rj11.yaml
+++ b/connectors/rj11/rj11.yaml
@@ -9,7 +9,9 @@ description: >
   to connect one set of modules to another over longer distances.
   Many hardware stores carry four-wire thin telephone cables. These
   four-wire cables can drive a small set of NeoPixels without issue.
-  Six-wire cables add `canbus`.
+  Current should probably not exceed 1A. Since the connector specifies
+  a 40V maximum, up to 40W is supported.
+  Six-wire RJ11 Retro Modules cables support `canbus`.
 keywords:
   - 6P2C
   - 6P4C
@@ -43,9 +45,9 @@ legacy_colors:
   5: yellow
   6: blue
 contacts:
-  1: controller-area-network-low
-  2: pixel-data
+  1: io-controller-area-network-low
+  2: io-pixel-data
   3: forty-volts-max
   4: common
-  5: one-wire-data
-  6: controller-area-network-high
+  5: io-common
+  6: io-controller-area-network-high

--- a/modules/adapters/adapter-power-brick/adapter-power-brick.yaml
+++ b/modules/adapters/adapter-power-brick/adapter-power-brick.yaml
@@ -6,10 +6,10 @@ description: >
   into your collection of modules. Most connectors in The Retro Specification
   have one or more `forty-volts-max` contacts. Power can be passed through
   one module to another with ease. If a module requires power, it can use
-  either power from the `fifteen-volts-max` bus or power from the
+  either power from the `six-volts-max` bus or power from the
   `forty-volts-max` bus. If a particular module is power-hungry, it should
   prefer power from the `forty-volts-max` bus... and could fall back to the
-  `fifteen-volts-max` bus if necessary (e.g. low-power mode).
+  `six-volts-max` bus if necessary (e.g. low-power mode).
   Many inexpensive voltage regulators can tolerate up to about forty volts.
   The power needs of one module may differ from that of another. A five volt
   regulator may be your regulator of choice, but certain modules may need

--- a/modules/adapters/adapter-usb-battery-pack/adapter-usb-battery-pack.yaml
+++ b/modules/adapters/adapter-usb-battery-pack/adapter-usb-battery-pack.yaml
@@ -5,8 +5,8 @@ description: >
   packs usually feature a LiPo battery, a 5V voltage regulator & charge
   controller. They typically are charged via a micro-USB port.
   Most of the connectors in The Retro Specification include both a
-  `forty-volts-max` and a `fifteen-volts-max` contact. Since Retro Modules are
+  `six-volts-max` and a `forty-volts-max` contact. Since Retro Modules are
   frequently daisy-chainable, power can be passed from one module to another.
   To use a USB Battery Pack as a power source, wire it up to the
-  `forty-volts-max` and/or the `fifteen-volts-max` contact(s). Just make sure
+  `six-volts-max` and/or the `forty-volts-max` contact(s). Just make sure
   it is the _only_ power source when you connect modules together.

--- a/modules/arduino-uno/arduino-uno.yaml
+++ b/modules/arduino-uno/arduino-uno.yaml
@@ -8,8 +8,9 @@ contacts:
   0: uart-receive
   1: uart-transmit
   2: interrupt
-  3: - interrupt-1
-     - pwm
+  3:
+    - interrupt-1
+    - pwm
   4:
   5: pwm-1
   6: pwm-2
@@ -24,7 +25,9 @@ contacts:
   15: adc-1
   16: adc-2
   17: adc-3
-  18: - adc-4
-      - i2c-data
-  19: - adc-5
-      - i2c-clock
+  18:
+    - adc-4
+    - io-i2c-data
+  19:
+    - adc-5
+    - io-i2c-clock

--- a/modules/client/adapters/adapter-power-brick/adapter-power-brick.yaml
+++ b/modules/client/adapters/adapter-power-brick/adapter-power-brick.yaml
@@ -6,10 +6,10 @@ description: >
   into your collection of modules. Most connectors in The Retro Specification
   have one or more `forty-volts-max` contacts. Power can be passed through
   one module to another with ease. If a module requires power, it can use
-  either power from the `fifteen-volts-max` bus or power from the
+  either power from the `six-volts-max` bus or power from the
   `forty-volts-max` bus. If a particular module is power-hungry, it should
   prefer power from the `forty-volts-max` bus... and could fall back to the
-  `fifteen-volts-max` bus if necessary (e.g. low-power mode).
+  `six-volts-max` bus if necessary (e.g. low-power mode).
   Many inexpensive voltage regulators can tolerate up to about twenty volts.
   The power needs of one module may differ from that of another. A five volt
   regulator may be your regulator of choice, but certain modules may need

--- a/modules/client/adapters/adapter-usb-battery-pack/adapter-usb-battery-pack.yaml
+++ b/modules/client/adapters/adapter-usb-battery-pack/adapter-usb-battery-pack.yaml
@@ -4,10 +4,6 @@ description: >
   Traditional USB ports provide five volts regulated power. Pocket USB battery
   packs usually feature a LiPo battery, a 5V voltage regulator & charge
   controller. They typically are charged via a micro-USB port.
-  Most of the connectors in The Retro Specification include a
-  `fifteen-volts-max` contact. Since Retro Modules are daisy-chainable,
-  that power is passed from one module to another. If a particular
-  module requires power, it can tap into the `fifteen-volts-max` bus.
 connectors:
   - dsub-db-25
   - usb-a

--- a/modules/client/power/battery/battery-smart.yaml
+++ b/modules/client/power/battery/battery-smart.yaml
@@ -35,12 +35,12 @@ proposals:
     scenarios:
       Given the host module requires an external battery
         And power is available on the `forty-volts-max` contact(s)
-        And power is available on `fifteen-volts-max` contact(s)
+        And power is available on `six-volts-max` contact(s)
           Then the host module should utilize power from the `forty-volts-max` contact(s)
           And client module(s) should utilize power from the `forty-volts-max` contact(s)
       Given the host module requires an external battery
         And power is not available on the `forty-volts-max` contact(s)
-        And power is available on the `fifteen-volts-max` contact(s)
-          Then the host module should utilize power from the `fifteen-volts-max` contact(s)
-          And client module(s) should utilize power from the `fifteen-volts-max` contact(s)
+        And power is available on the `six-volts-max` contact(s)
+          Then the host module should utilize power from the `six-volts-max` contact(s)
+          And client module(s) should utilize power from the `six-volts-max` contact(s)
           And client module(s) should conserve power wherever possible

--- a/modules/client/power/battery/battery.yaml
+++ b/modules/client/power/battery/battery.yaml
@@ -2,7 +2,7 @@ name: Battery Module
 summary: A self-contained rechargeable battery module.
 description: >
   Most connectors in the Retro Specification feature a `forty-volts-max` pin.
-  Many also feature a `fifteen-volts-max` pin. Ideally, the `battery`
+  Many also feature a `six-volts-max` pin. Ideally, the `battery`
   module's internal charging circuitry would properly charge its battery from
   the `forty-volts-max` pin.
   The contacts dedicated to power distribution are a tricky subject. Suppose

--- a/modules/client/raspberry-pi/raspberry-pi.yaml
+++ b/modules/client/raspberry-pi/raspberry-pi.yaml
@@ -7,9 +7,9 @@ voltage-max-input: 5
 pi3_contacts:
   1: three-point-three-volts-regulated
   2: regulated-five-volts
-  3: i2c-data
+  3: io-i2c-data
   4: regulated-five-volts
-  5: i2c-clock
+  5: io-i2c-clock
   6:
   7:
   8: uart-transmit
@@ -27,7 +27,7 @@ pi3_contacts:
   20:
   21: spi-master-in-slave-out
   22:
-  23: spi-clock
+  23: io-spi-clock
   24: spi-slave-select
   25:
   26:

--- a/modules/host/arduino-uno/arduino-uno.yaml
+++ b/modules/host/arduino-uno/arduino-uno.yaml
@@ -8,8 +8,9 @@ contacts:
   0: uart-receive
   1: uart-transmit
   2: interrupt
-  3: - interrupt-1
-     - pwm
+  3:
+    - interrupt-1
+    - pwm
   4:
   5: pwm-1
   6: pwm-2
@@ -24,7 +25,9 @@ contacts:
   15: adc-1
   16: adc-2
   17: adc-3
-  18: - adc-4
-      - i2c-data
-  19: - adc-5
-      - i2c-clock
+  18:
+    - adc-4
+    - io-i2c-data
+  19:
+    - adc-5
+    - io-i2c-clock

--- a/modules/host/ioio-otg/ioio-otg.yaml
+++ b/modules/host/ioio-otg/ioio-otg.yaml
@@ -10,13 +10,13 @@ todo:
      & clock pins for the bus with the lowest numeric value
      (DA0/CL0 instead of DA1/CL1).
 contacts:
-  'i2c-data':
+  io-i2c-data:
     - 4
     - 1
-  'i2c-clock':
+  io-i2c-clock:
     - 5
     - 2
-  'spi-slave-select': 'tbd'
-  'spi-master-out-slave-in': 'tbd'
-  'spi-master-in-slave-out': 'tbd'
-  'spi-clock': 'tbd'
+  io-spi-chip-select: tbd
+  io-spi-controller-out-peripheral-in: tbd
+  io-spi-controller-in-peripheral-out: tbd
+  io-spi-clock: tbd

--- a/modules/host/pro-micro/pro-micro.yaml
+++ b/modules/host/pro-micro/pro-micro.yaml
@@ -8,25 +8,28 @@ voltage-max-input: 12
 contacts:
   0: uart-receive
   1: uart-transmit
-  2: i2c-data
-  3: - i2c-clock
-     - pwm
+  2: io-i2c-data
+  3:
+    - io-i2c-clock
+    - pwm
   4: adc-6
   5: pwm-1
   6: adc-7
      - pwm-2
   7:
   8: adc-8
-  9: - adc-9
-     - pwm-3
-  10: - adc-10
-      - pwm-4
+  9:
+    - adc-9
+    - pwm-3
+  10:
+    - adc-10
+    - pwm-4
   11:
   12:
   13:
-  14: spi-master-in-slave-out
-  15: spi-clock
-  16: spi-master-out-slave-in
+  14: spi-controller-in-peripheral-out
+  15: io-spi-clock
+  16: spi-controller-out-peripheral-in
   17:
   18: adc-0
   19: adc-1

--- a/modules/host/pro-trinket/pro-trinket.yaml
+++ b/modules/host/pro-trinket/pro-trinket.yaml
@@ -8,23 +8,26 @@ contacts:
   0: uart-rx
   1: uart-tx
   2:
-  3: - interrupt
-     - pwm
+  3:
+    - interrupt
+    - pwm
   4:
   5: pwm-1
   6: pwm-2
   7:
   8:
   9:
-  10: spi-slave-select
-  11: spi-master-out-slave-in
-  12: spi-master-in-slave-out
-  13: spi-clock 
+  10: spi-chip-select
+  11: spi-controller-out-peripheral-in
+  12: spi-controller-in-peripheral-out
+  13: io-spi-clock
   14: adc
   15: adc-1
   16: adc-2
   17: adc-3
-  18: - i2c-data
-      - adc-4
-  19: - i2c-clock
-      - adc-5
+  18:
+    - io-i2c-data
+    - adc-4
+  19:
+    - io-i2c-clock
+    - adc-5

--- a/modules/host/teensy3/teensy3.yaml
+++ b/modules/host/teensy3/teensy3.yaml
@@ -10,39 +10,51 @@ reference:
 voltage: 3.3
 max-voltage-input: 6
 contacts:
-  0: - uart-receive
-     - touch-sense
-  1: - uart-transmit
-     - touch-sense-1
+  0:
+    - uart-receive
+    - touch-sense
+  1:
+    - uart-transmit
+    - touch-sense-1
   2:
-  3: - controller-area-network-transceiver-tx
-     - pwm
-  4: - controller-area-network-transceiver-rx
-     - pwm-1
+  3:
+    - controller-area-network-transceiver-tx
+    - pwm
+  4:
+    - controller-area-network-transceiver-rx
+    - pwm-1
   5: pwm-2
   6: pwm-3
   7: uart-receive-2
   8: uart-transmit-2
-  9: - uart-receive-1
-     - pwm-4
-  10: - uart-transmit-1
-      - pwm-5
-  11: spi-master-out-slave-in
-  12: spi-master-in-slave-out
-  13: spi-clock
+  9:
+    - uart-receive-1
+    - pwm-4
+  10:
+    - uart-transmit-1
+    - pwm-5
+  11: spi-controller-out-peripheral-in
+  12: spi-controller-in-peripheral-out
+  13: io-spi-clock
   14: adc
   15: adc-1
-  16: - i2c-clock-1
-      - adc-2
-  17: - i2c-data-1
-      - adc-3
-  18: - i2c-data
-      - adc-4
-  19: - i2c-clock
-      - adc-5
-  20: - adc-6
-  21: - adc-7
-  22: - touch-sence-2
-      - adc-8
-  23: - touch-sense-3
-      - adc-9
+  16:
+    - io-i2c-clock-1
+    - adc-2
+  17:
+    - io-i2c-data-1
+    - adc-3
+  18:
+    - io-i2c-data
+    - adc-4
+  19:
+    - io-i2c-clock
+    - adc-5
+  20: adc-6
+  21: adc-7
+  22:
+    - touch-sence-2
+    - adc-8
+  23:
+    - touch-sense-3
+    - adc-9

--- a/modules/host/trinket/trinket.yaml
+++ b/modules/host/trinket/trinket.yaml
@@ -5,11 +5,13 @@ voltage:
   - 3.3
   - 5
 contacts:
-  0: - spi-master-in-slave-out
-     - i2c-data
-  1: spi-master-out-slave-in
-  2: - spi-clock
-     - i2c-clock
-     - adc-1
+  0:
+    - spi-controller-in-peripheral-out
+    - io-i2c-data
+  1: spi-controller-out-peripheral-in
+  2:
+    - io-spi-clock
+    - io-i2c-clock
+    - adc-1
   3: adc-3
   4: adc-2

--- a/modules/ioio-otg/ioio-otg.yaml
+++ b/modules/ioio-otg/ioio-otg.yaml
@@ -10,13 +10,13 @@ todo:
      & clock pins for the bus with the lowest numeric value
      (DA0/CL0 instead of DA1/CL1).
 contacts:
-  'i2c-data':
+  io-i2c-data':
     - 4
     - 1
-  'i2c-clock':
+  io-i2c-clock':
     - 5
     - 2
-  'spi-chip-select': 'tbd'
-  'spi-controller-out-peripheral-in': 'tbd'
-  'spi-controller-in-peripheral-out': 'tbd'
-  'spi-clock': 'tbd'
+  io-spi-chip-select: tbd
+  io-spi-controller-out-peripheral-in: tbd
+  io-spi-controller-in-peripheral-out: tbd
+  io-spi-clock': tbd

--- a/modules/power/battery/battery.yaml
+++ b/modules/power/battery/battery.yaml
@@ -2,7 +2,7 @@ name: Battery Module
 summary: A self-contained rechargeable battery module.
 description: >
   Most connectors in the Retro Specification feature a `forty-volts-max` pin.
-  Many also feature a `fifteen-volts-max` pin. Ideally, the `battery`
+  Many also feature a `six-volts-max` pin. Ideally, the `battery`
   module's internal charging circuitry would properly charge its battery from
   the `forty-volts-max` pin.
   The contacts dedicated to power distribution are a tricky subject. Suppose

--- a/modules/pro-micro/pro-micro.yaml
+++ b/modules/pro-micro/pro-micro.yaml
@@ -8,25 +8,28 @@ voltage-max-input: 12
 contacts:
   0: uart-receive
   1: uart-transmit
-  2: i2c-data
-  3: - i2c-clock
-     - pwm
+  2: io-i2c-data
+  3:
+    - io-i2c-clock
+    - pwm
   4: adc-6
   5: pwm-1
   6: adc-7
      - pwm-2
   7:
   8: adc-8
-  9: - adc-9
-     - pwm-3
-  10: - adc-10
-      - pwm-4
+  9:
+    - adc-9
+    - pwm-3
+  10:
+    - adc-10
+    - pwm-4
   11:
   12:
   13:
-  14: spi-controller-in-peripheral-out
-  15: spi-clock
-  16: spi-controller-out-peripheral-in
+  14: io-spi-controller-in-peripheral-out
+  15: io-spi-clock
+  16: io-spi-controller-out-peripheral-in
   17:
   18: adc-0
   19: adc-1

--- a/modules/pro-trinket/pro-trinket.yaml
+++ b/modules/pro-trinket/pro-trinket.yaml
@@ -8,23 +8,26 @@ contacts:
   0: uart-rx
   1: uart-tx
   2:
-  3: - interrupt
-     - pwm
+  3:
+    - interrupt
+    - pwm
   4:
   5: pwm-1
   6: pwm-2
   7:
   8:
   9:
-  10: spi-chip-select
-  11: spi-controller-out-peripheral-in
-  12: spi-controller-in-peripheral-out
-  13: spi-clock 
+  10: io-spi-chip-select
+  11: io-spi-controller-out-peripheral-in
+  12: io-spi-controller-in-peripheral-out
+  13: io-spi-clock
   14: adc
   15: adc-1
   16: adc-2
   17: adc-3
-  18: - i2c-data
-      - adc-4
-  19: - i2c-clock
-      - adc-5
+  18:
+    - io-i2c-data
+    - adc-4
+  19:
+    - io-i2c-clock
+    - adc-5

--- a/modules/raspberry-pi/raspberry-pi.yaml
+++ b/modules/raspberry-pi/raspberry-pi.yaml
@@ -7,9 +7,9 @@ voltage-max-input: 5
 pi3_contacts:
   1: three-point-three-volts-regulated
   2: regulated-five-volts
-  3: i2c-data
+  3: io-i2c-data
   4: regulated-five-volts
-  5: i2c-clock
+  5: io-i2c-clock
   6:
   7:
   8: uart-transmit
@@ -23,12 +23,12 @@ pi3_contacts:
   16:
   17:
   18:
-  19: spi-controller-out-peripheral-in
+  19: io-spi-controller-out-peripheral-in
   20:
-  21: spi-controller-in-peripheral-out
+  21: io-spi-controller-in-peripheral-out
   22:
-  23: spi-clock
-  24: spi-chip-select
+  23: io-spi-clock
+  24: io-spi-chip-select
   25:
   26:
   27:

--- a/modules/teensy3/teensy3.yaml
+++ b/modules/teensy3/teensy3.yaml
@@ -10,39 +10,53 @@ reference:
 voltage: 3.3
 max-voltage-input: 6
 contacts:
-  0: - uart-receive
-     - touch-sense
-  1: - uart-transmit
-     - touch-sense-1
+  0:
+    - uart-receive
+    - touch-sense
+  1:
+    - uart-transmit
+    - touch-sense-1
   2:
-  3: - controller-area-network-transceiver-tx
-     - pwm
-  4: - controller-area-network-transceiver-rx
-     - pwm-1
+  3:
+    - controller-area-network-transceiver-tx
+    - pwm
+  4:
+    - controller-area-network-transceiver-rx
+    - pwm-1
   5: pwm-2
   6: pwm-3
   7: uart-receive-2
   8: uart-transmit-2
-  9: - uart-receive-1
-     - pwm-4
-  10: - uart-transmit-1
-      - pwm-5
-  11: spi-controller-out-peripheral-in
-  12: spi-controller-in-peripheral-out
-  13: spi-clock
+  9:
+    - uart-receive-1
+    - pwm-4
+  10:
+    - uart-transmit-1
+    - pwm-5
+  11: io-spi-controller-out-peripheral-in
+  12: io-spi-controller-in-peripheral-out
+  13: io-spi-clock
   14: adc
   15: adc-1
-  16: - i2c-clock-1
-      - adc-2
-  17: - i2c-data-1
-      - adc-3
-  18: - i2c-data
-      - adc-4
-  19: - i2c-clock
-      - adc-5
-  20: - adc-6
-  21: - adc-7
-  22: - touch-sence-2
-      - adc-8
-  23: - touch-sense-3
-      - adc-9
+  16:
+    - io-i2c-clock-1
+    - adc-2
+  17:
+    - io-i2c-data-1
+    - adc-3
+  18:
+    - io-i2c-data
+    - adc-4
+  19:
+    - io-i2c-clock
+    - adc-5
+  20:
+    - adc-6
+  21:
+    - adc-7
+  22:
+    - touch-sence-2
+    - adc-8
+  23:
+    - touch-sense-3
+    - adc-9

--- a/modules/trinket/trinket.yaml
+++ b/modules/trinket/trinket.yaml
@@ -5,11 +5,13 @@ voltage:
   - 3.3
   - 5
 contacts:
-  0: - spi-controller-in-peripheral-out
-     - i2c-data
-  1: spi-controller-out-peripheral-in
-  2: - spi-clock
-     - i2c-clock
-     - adc-1
+  0:
+    - io-spi-controller-in-peripheral-out
+    - io-i2c-data
+  1: io-spi-controller-out-peripheral-in
+  2:
+    - io-spi-clock
+    - io-i2c-clock
+    - adc-1
   3: adc-3
   4: adc-2


### PR DESCRIPTION
This pull request optimizes the main connectors to reduce the need for numerous compact voltage regulators & further refines clean signal support.

If there are no objections, this PR will be merged on or after June 20th, 2021.

- Adds dedicated common bus for digital signals on many connectors.
- Revises main connectors to support 6 & 40 volts max contacts.
- Adds support for balanced audio on main 25 contact connectors.